### PR TITLE
[IMP] 14.0 Update to use official python 3.8 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,69 +1,32 @@
 
-# Based on official odoo Dockerfile: https://github.com/odoo/docker/blob/master/14.0/Dockerfile
-# with Junari extensions (Git, Node, Nano)
-
-FROM debian:buster-slim
+FROM python:3.8-slim-bullseye
 
 SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
 ARG ODOO_VERSION
 ARG ODOO_REVISION
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Generate locale C.UTF-8 for postgres and general locale data
 ENV LANG C.UTF-8
 
-# Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
-# (packages from 'nano' onwards are junari customisations)
+# Install dependencies (from Odoo install documentation)
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        ca-certificates \
-        curl \
-        dirmngr \
-        fonts-noto-cjk \
-        gnupg \
-        libssl-dev \
-        node-less \
-        npm \
-        python3-num2words \
-        python3-pdfminer \
-        python3-pip \
-        python3-phonenumbers \
-        python3-pyldap \
-        python3-qrcode \
-        python3-renderpm \
-        python3-setuptools \
-        python3-slugify \
-        python3-vobject \
-        python3-watchdog \
-        python3-xlrd \
-        python3-xlwt \
-        xz-utils \
-        nano \
-        git \
-        openssh-client \
-        build-essential \
-        python3-dev \
-    && curl -o wkhtmltox.deb -sSL https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.buster_amd64.deb \
-    && echo 'ea8277df4297afc507c61122f3c349af142f31e5 wkhtmltox.deb' | sha1sum -c - \
-    && apt-get install -y --no-install-recommends ./wkhtmltox.deb \
-    && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
+    apt-get install -y libxml2-dev libxslt1-dev libldap2-dev libsasl2-dev \
+    libtiff5-dev libjpeg-dev libopenjp2-7-dev zlib1g-dev libfreetype6-dev \
+    liblcms2-dev libwebp-dev libharfbuzz-dev libfribidi-dev libxcb1-dev libpq-dev
 
-# install latest postgresql-client
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
-    && GNUPGHOME="$(mktemp -d)" \
-    && export GNUPGHOME \
-    && repokey='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8' \
-    && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
-    && gpg --batch --armor --export "${repokey}" > /etc/apt/trusted.gpg.d/pgdg.gpg.asc \
-    && gpgconf --kill all \
-    && rm -rf "$GNUPGHOME" \
-    && apt-get update  \
-    && apt-get install --no-install-recommends -y postgresql-client \
-    && rm -f /etc/apt/sources.list.d/pgdg.list \
-    && rm -rf /var/lib/apt/lists/*
+# Install additional tools needed for build & run
+RUN apt-get install -y \
+    gcc g++ curl git nano
+
+# install wkhtmltox for PDF reports
+RUN curl -o wkhtmltox.deb -sSL https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.bullseye_amd64.deb \
+    && apt-get install -y ./wkhtmltox.deb \
+    && rm wkhtmltox.deb
 
 # Install Node
-RUN curl -fsSL https://deb.nodesource.com/setup_15.x | bash -
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
 RUN apt-get install -y nodejs
 
 # Create odoo user and directories and set permissions
@@ -78,6 +41,7 @@ USER odoo
 RUN git clone --branch=$ODOO_VERSION --depth=1000 https://github.com/odoo/odoo.git odoo
 RUN cd odoo && git reset --hard $ODOO_REVISION
 
+# Install Odoo python package requirements
 USER root
 RUN pip3 install pip --upgrade
 RUN pip3 install --no-cache-dir -r odoo/requirements.txt

--- a/build.env
+++ b/build.env
@@ -1,3 +1,3 @@
 
 export ODOO_VERSION="14.0"
-export ODOO_REVISION="fd90820"
+export ODOO_REVISION="6cd60e8"

--- a/odoo.env-example
+++ b/odoo.env-example
@@ -2,4 +2,4 @@ DB_HOST=host.docker.internal
 DB_PORT=5432
 DB_USER=odoo
 DB_PASSWORD=odoo
-ODOO_EXTRA_ARGS= --db-filter=^%d$
+ODOO_EXTRA_ARGS=

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
-cd odoo
 if [ "$1" = 'odoo' ]; then
     shift
+    cd odoo
     exec ./odoo-bin \
         "--db_host=$DB_HOST" \
         "--db_port=$DB_PORT" \


### PR DESCRIPTION
- Update from Ubuntu 18.04 base to official python 3.8 / debian bullseye image which is supported to 2026
- Remove lots of unnecessary package installs
- Update to latest odoo 14